### PR TITLE
added hash to navigateError function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default class Router {
         return this;
       }
     }
-    this.navigateError();
+    this.navigateError(hash);
     return this;
   }
 
@@ -62,7 +62,7 @@ export default class Router {
     return this;
   }
 
-  navigateError() {
+  navigateError(hash) {
     if (this.debug) {
       console.log(`%c[Router] Failed %cFetching: /${hash}, not a valid route.`, 'color: rgb(255, 105, 100);', 'color: inherit');
     }


### PR DESCRIPTION
When activate debug in home route, error is raised 

        const router = new Router(true)
           .add(() => { // no / added because is home
               const home = new HomeController();
         });

> index.js?c715:67 Uncaught ReferenceError: hash is not defined
>     at Router.navigateError (index.js?c715:67)
>     at Router.check (index.js?c715:42)
>     at Router.listen (index.js?c715:47)
>     at window.addEventListener (index.js?1fdf:38)

Just add **hash** to _navigateError_ solve this problem.
