### PR TITLE
Feature: Disable listen on construct

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,16 @@ export default class Router {
    * Create a new instance of a client side router
    * @param {boolean} [debug=false] - Enable debugging console messages
    * @param {boolean} [context=Window] - Context to listen for changes on
+   * @param {boolean} [initiate=true] - Initiate listen on construct
    */
-  constructor(debug = false, context) {
+  constructor(debug = false, context = window, initiate = true) {
     this.debug = debug;
     this.routes = [];
     this.onHashChange = this.check.bind(this);
-    this.listen(context);
+    this.context = context;
+    if (true === initiate) {
+      this.listen(this.context);
+    }
   }
 
   /**
@@ -105,7 +109,7 @@ export default class Router {
    */
   listen(instance) {
     this.check();
-    (instance || window).addEventListener('hashchange', this.onHashChange);
+    (instance || this.context || window).addEventListener('hashchange', this.onHashChange);
     return this;
   }
 
@@ -115,7 +119,7 @@ export default class Router {
    * @returns {Router} - This router instance
    */
   stopListen(instance) {
-    (instance || window).removeEventListener('hashchange', this.onHashChange);
+    (instance || this.context || window).removeEventListener('hashchange', this.onHashChange);
     return this;
   }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -140,3 +140,32 @@ test('StopListen', () => {
 
   expect(i).toEqual(1);
 });
+
+test('Do not init listen on construct', () => {
+  let i = 0;
+
+  const router = new Router(false, window, false);
+  router.add(() => {
+    i = 1;
+  });
+
+  Object.defineProperty(window.location, 'hash', {
+    writable: true,
+    value: '#/'
+  });
+  const firstHashChangeEvent = new Event('hashchange');
+  window.dispatchEvent(firstHashChangeEvent);
+
+  expect(i).toEqual(0);
+
+  router.listen();
+
+  Object.defineProperty(window.location, 'hash', {
+    writable: true,
+    value: '#/'
+  });
+  const lastHashChangeEvent = new Event('hashchange');
+  window.dispatchEvent(lastHashChangeEvent);
+
+  expect(i).toEqual(1);
+});


### PR DESCRIPTION
If you want to use the router in e.g. an overlay and enable it by displaying the overlay you need to disable the listen on construct.

Added a test and the necessary changes, so that you save the context for your event handlers.